### PR TITLE
Using the release tag as the Docker tag instead of the release title.

### DIFF
--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -5,31 +5,14 @@ on:
     types: [published]
 
 jobs:
-  build:
-    name: Create and Push Release Docker Images to DockerHub
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Login to DockerHub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Build React Docker Image and Push to DockerHub
-      uses: docker/build-push-action@v5
-      with:
-        context: ./react-app
-        push: true
-        tags: ${{ secrets.DOCKERHUB_USERNAME }}/springboot-devops_react:${{ github.event.release.tag_name }}
-
-    - name: Build Spring Boot Docker Image and Push to DockerHub
-      uses: docker/build-push-action@v5
-      with:
-        context: ./springboot
-        push: true
-        tags: ${{ secrets.DOCKERHUB_USERNAME }}/springboot-devops_springboot:${{ github.event.release.tag_name }}
+  call-push-docker-images:
+    name: Call Push Docker Images Workflow for Release Images
+    uses: dobsondev/springboot-devops/.github/workflows/push-docker-images.yml@main
+    with:
+      buildReactDockerImage: true
+      reactDockerTag: ${{ github.event.release.tag_name }}
+      buildSpringbootDockerImage: true
+      springbootDockerTag: ${{ github.event.release.tag_name }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Made the new release workflow DRY and using the release tag as the Docker tag instead of the release title.